### PR TITLE
add workaround / fix for time.resolution handling

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2025 Tom Kralidis
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -31,6 +31,7 @@ import logging
 from pathlib import Path
 import uuid
 
+from jsonschema import FormatChecker
 from jsonschema.validators import Draft202012Validator
 from shapely.geometry import shape
 
@@ -134,7 +135,8 @@ class WMOCoreMetadataProfileTestSuite2:
 
         with schema.open() as fh:
             LOGGER.debug(f'Validating {self.record} against {schema}')
-            validator = Draft202012Validator(json.load(fh))
+            validator = Draft202012Validator(
+                json.load(fh), format_checker=FormatChecker(formats=['regex']))
 
             for error in validator.iter_errors(self.record):
                 LOGGER.debug(f'{error.json_path}: {error.message}')

--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -29,6 +29,7 @@ import csv
 import json
 import logging
 from pathlib import Path
+import re
 import uuid
 
 from jsonschema import FormatChecker
@@ -264,11 +265,22 @@ class WMOCoreMetadataProfileTestSuite2:
         Validate that a WCMP record provides a valid temporal extent property.
         """
 
+        # FIXME: remove this check once the regex is applied as a
+        # JSON Schema pattern in WCMP2
+        # https://github.com/wmo-im/wcmp2/issues/244
         status = {
             'id': gen_test_id('extent_temporal'),
             'code': 'PASSED',
             'message': 'Passes given schema is compliant/valid'
         }
+
+        duration_regex = r'^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$'  # noqa
+
+        resolution = self.record['time'].get('resolution')
+        if resolution is not None:
+            if re.search(duration_regex, resolution) is None:
+                status['code'] = 'FAILED'
+                status['message'] = 'Invalid time resolution'
 
         return status
 

--- a/tests/data/wcmp2-failing-created-none.json
+++ b/tests/data/wcmp2-failing-created-none.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-centre-id.json
+++ b/tests/data/wcmp2-failing-invalid-centre-id.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-geometry-range.json
+++ b/tests/data/wcmp2-failing-invalid-geometry-range.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-identifier-empty.json
+++ b/tests/data/wcmp2-failing-invalid-identifier-empty.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-identifier-space.json
+++ b/tests/data/wcmp2-failing-invalid-identifier-space.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-link-channel-wis2-topic.json
+++ b/tests/data/wcmp2-failing-invalid-link-channel-wis2-topic.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-failing-invalid-time-resolution.json
+++ b/tests/data/wcmp2-failing-invalid-time-resolution.json
@@ -1,0 +1,161 @@
+{
+    "id": "urn:wmo:md:ca-eccc-msc:weather.observations.swob-realtime",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
+    ],
+    "time": {
+        "interval": [
+            "2010-11-11T11:11:11Z",
+            ".."
+        ],
+        "resolution": "P1H"
+    },
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -142,
+                    28
+                ],
+                [
+                    -142,
+                    82
+                ],
+                [
+                    -52,
+                    82
+                ],
+                [
+                    -52,
+                    28
+                ],
+                [
+                    -142,
+                    28
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "title": "Surface weather observations",
+        "description": "Surface Observations measured at the automatic and manual stations of the Environment and Climate Change Canada and partners networks, either for a single station, or for the stations of specific provinces and territories (last 30 days)",
+        "themes": [
+            {
+                "concepts": [
+                    {
+                        "id": "Weather"
+                    },
+                    {
+                        "id": "Archives"
+                    },
+                    {
+                        "id": "Precipitation"
+                    },
+                    {
+                        "id": "Air temperature"
+                    },
+                    {
+                        "id": "Humidity"
+                    },
+                    {
+                        "id": "Snow"
+                    },
+                    {
+                        "id": "Wind"
+                    },
+                    {
+                        "id": "Meteorological data"
+                    }
+                ],
+                "scheme": "https://library-archives.canada.ca/eng/services/government-canada/controlled-vocabularies-government-canada/pages/controlled-vocabularies-government-canada.aspx"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "weather"
+                    }
+                ],
+                "scheme": "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+            }
+        ],
+        "contacts": [
+            {
+                "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+                "position": "National Inquiry Response Team",
+                "phones": [
+                    {
+                        "value": "+18199972800"
+                    }
+                ],
+                "emails": [
+                    {
+                        "value": "enviroinfo@ec.gc.ca"
+                    }
+                ],
+                "addresses": [
+                    {
+                        "deliveryPoint": [
+                            "77 Westmorland Street, suite 260"
+                        ],
+                        "city": "Fredericton",
+                        "administrativeArea": "NB",
+                        "postalCode": "E3B 6Z4",
+                        "country": "Canada"
+                    }
+                ],
+                "links": [
+                    {
+                        "rel": "canonical",
+                        "type": "text/html",
+                        "href": "https://eccc-msc.github.io/open-data"
+                    }
+                ],
+                "contactInstructions": "via email",
+                "roles": [
+                    "host",
+                    "producer"
+                ]
+            }
+        ],
+        "type": "dataset",
+        "created": "2018-01-01T11:11:11Z",
+        "updated": "2022-06-22T12:42:46Z",
+        "wmo:dataPolicy": "core"
+    },
+    "links": [
+        {
+            "rel": "stations",
+            "href": "https://dd.weather.gc.ca/observations/doc/swob-xml_station_list.csv",
+            "type": "text/csv",
+            "title": "Stations associated with this dataset"
+        },
+        {
+            "rel": "data",
+            "href": "https://dd.weather.gc.ca/observations/swob-ml",
+            "type": "text/html",
+            "hreflang": "en",
+            "title": "Raw data download (CSV files)"
+        },
+        {
+            "rel": "items",
+            "href": "https://api.weather.gc.ca/collections/swob-realtime/items",
+            "type": "application/json",
+            "title": "Data access API interface"
+        },
+        {
+            "rel": "related",
+            "href": "https://eccc-msc.github.io/open-data/msc-data/obs_station/readme_obs_insitu_swobdatamart_en",
+            "type": "text/html",
+            "title": "Documentation"
+        },
+        {
+            "rel": "items",
+            "href": "mqtt://example.org:8883",
+            "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/experimental/surface-based-observations/synop",
+            "type": "application/json",
+            "title": "Data notifications"
+        }
+    ]
+}

--- a/tests/data/wcmp2-passing-test-centre-id.json
+++ b/tests/data/wcmp2-passing-test-centre-id.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/data/wcmp2-passing.json
+++ b/tests/data/wcmp2-passing.json
@@ -8,7 +8,7 @@
             "2010-11-11T11:11:11Z",
             ".."
         ],
-        "resolution": "P1H"
+        "resolution": "PT1H"
     },
     "type": "Feature",
     "geometry": {

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -114,6 +114,20 @@ class WCMP2ETSTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 ts.run_tests(fail_on_schema_validation=True)
 
+    def test_fail_invalid_time_resolution(self):
+        """Simple test for a failing record with an invalid time resolution"""
+
+        with open(get_test_file_path('data/wcmp2-failing-invalid-time-resolution.json')) as fh:  # noqa
+            record = json.load(fh)
+            ts = WMOCoreMetadataProfileTestSuite2(record)
+            results = ts.run_tests(fail_on_schema_validation=True)
+
+            codes = [r['code'] for r in results['tests']]
+
+            self.assertEqual(codes.count('FAILED'), 1)
+            self.assertEqual(codes.count('PASSED'), 11)
+            self.assertEqual(codes.count('SKIPPED'), 0)
+
     def test_fail_created_none(self):
         """Simple tests for a failing record with an invalid creation date"""
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -63,7 +63,7 @@ class WCMP2ETSTest(unittest.TestCase):
             data = json.load(fh)
 
         ts = WMOCoreMetadataProfileTestSuite2(data)
-        results = ts.run_tests()
+        results = ts.run_tests(fail_on_schema_validation=True)
 
         self.assertEqual(results['report_type'], 'ets')
         self.assertEqual(results['metadata_id'], data['id'])
@@ -79,7 +79,7 @@ class WCMP2ETSTest(unittest.TestCase):
 
         with open(get_test_file_path('data/wcmp2-passing-test-centre-id.json')) as fh:  # noqa
             ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
-            results = ts.run_tests()
+            results = ts.run_tests(fail_on_schema_validation=True)
 
             codes = [r['code'] for r in results['tests']]
 


### PR DESCRIPTION
- fixes ISO 8601 duration in examples (thanks @maaikelimper @david-i-berry)
- updates code to add regex checking workaround until defined in WCMP2 JSON Schema (https://github.com/wmo-im/wcmp2/issues/244)
- add extra validation check/arg in tests for passing records