### PR TITLE
use native jsonschema checks for string formats

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -41,8 +41,7 @@ from pywis_topics.topics import TopicHierarchy
 import pywcmp
 from pywcmp.errors import TestSuiteError
 from pywcmp.bundle import WCMP2_FILES
-from pywcmp.util import (get_current_datetime_rfc3339, get_userdir,
-                         is_valid_created_datetime)
+from pywcmp.util import get_current_datetime_rfc3339, get_userdir
 
 LOGGER = logging.getLogger(__name__)
 
@@ -139,6 +138,9 @@ class WMOCoreMetadataProfileTestSuite2:
 
         validation_errors = []
 
+        format_checkers = ['date-time', 'email', 'regex',
+                           'uri', 'uri-reference']
+
         status = {
             'id': gen_test_id('validation'),
             'code': 'PASSED'
@@ -154,7 +156,9 @@ class WMOCoreMetadataProfileTestSuite2:
         with schema.open() as fh:
             LOGGER.debug(f'Validating {self.record} against {schema}')
             validator = Draft202012Validator(
-                json.load(fh), format_checker=FormatChecker(formats=['regex']))
+                json.load(fh),
+                format_checker=FormatChecker(formats=format_checkers)
+            )
 
             for error in validator.iter_errors(self.record):
                 LOGGER.debug(f'{error.json_path}: {error.message}')
@@ -426,15 +430,10 @@ class WMOCoreMetadataProfileTestSuite2:
         """
 
         status = {
-            'id': gen_test_id('record_created_datetime'),
-            'code': 'PASSED'
+            'id': gen_test_id('conformance'),
+            'code': 'PASSED',
+            'message': 'Passes given schema is compliant/valid'
         }
-
-        created = self.record['properties']['created']
-
-        if not is_valid_created_datetime(created):
-            status['code'] = 'FAILED'
-            status['message'] = 'Invalid date-time format'
 
         return status
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 beautifulsoup4
 click
-jsonschema>4.19
+jsonschema
 pyspellchecker
 pywis-topics
+rfc3339-validator
+rfc3987
 shapely

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -34,7 +34,7 @@ from pywcmp.errors import TestSuiteError
 from pywcmp.ets import WMOCoreMetadataProfileTestSuite2
 from pywcmp.wcmp2.kpi import (
     calculate_grade, WMOCoreMetadataProfileKeyPerformanceIndicators)
-from pywcmp.util import is_valid_created_datetime, parse_wcmp
+from pywcmp.util import parse_wcmp
 
 
 def get_test_file_path(filename):
@@ -155,16 +155,10 @@ class WCMP2ETSTest(unittest.TestCase):
     def test_fail_created_none(self):
         """Simple tests for a failing record with an invalid creation date"""
 
-        with open(get_test_file_path('data/wcmp2-failing-created-none.json')) as fh:  # noqa
-            record = json.load(fh)
-            ts = WMOCoreMetadataProfileTestSuite2(record)
-            results = ts.run_tests()
-
-            codes = [r['code'] for r in results['tests']]
-
-            self.assertEqual(codes.count('FAILED'), 1)
-            self.assertEqual(codes.count('PASSED'), 11)
-            self.assertEqual(codes.count('SKIPPED'), 0)
+        with self.assertRaises(ValueError):
+            with open(get_test_file_path('data/wcmp2-failing-created-none.json')) as fh:  # noqa
+                ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
+                _ = ts.run_tests(fail_on_schema_validation=True)
 
     def test_fail_invalid_link_channel_wis2_topic(self):
         """
@@ -317,14 +311,6 @@ class WCMPUtilTest(unittest.TestCase):
         file_ = 'data/wcmp2-passing.json'
         with open(get_test_file_path(file_)) as fh:
             _ = parse_wcmp(fh.read())
-
-    def test_is_valid_created_datetime(self):
-        """test for valid/accepted RFC3339 datetimes"""
-
-        self.assertTrue(is_valid_created_datetime('2024-08-09T14:29:22Z'))
-        self.assertTrue(is_valid_created_datetime('2024-08-09T14:29:22.12Z'))
-        self.assertTrue(is_valid_created_datetime('2024-08-09T14:29:22+0400'))
-        self.assertTrue(is_valid_created_datetime('2024-08-09T14:29:22+04:00'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds jsonschema string/format checks, given WCMP2 defines some `string` types with `format` (i.e. `date-time`, `uri`, `regex`, etc.).  This puts more of the validation into the hands of JSON schema and the associated Python tooling.

I've also unpinned jsonschema from `requirements.txt` (circa 2023).