### PR TITLE
add comparison check between MQTT channel and data policy

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -506,8 +506,11 @@ class WMOCoreMetadataProfileTestSuite2:
                     return status
 
                 if link['channel'].startswith(('origin/a/wis2', 'cache/a/wis2')):  # noqa
+                    channel_tokens = link['channel'].split('/')
                     try:
-                        centre_id = link['channel'].split('/')[3]
+                        LOGGER.debug('Validating centre-id in topic')
+                        centre_id = channel_tokens[3]
+
                         if (not centre_id.endswith('-test') and
                                 centre_id not in self.th.topics[3]):
                             status['code'] = 'FAILED'
@@ -515,6 +518,19 @@ class WMOCoreMetadataProfileTestSuite2:
                             return status
                     except IndexError:
                         LOGGER.debug('Topic has no centre-id')
+
+                    try:
+                        LOGGER.debug('Validating data policy in channel with record properties.wmo:dataPolicy')  # noqa
+                        notification_type = channel_tokens[4]
+                        if notification_type == 'data':
+                            channel_data_policy = channel_tokens[5]
+                            if channel_data_policy != self.record['properties']['wmo:dataPolicy']:  # noqa
+                                status['code'] = 'FAILED'
+                                status['message'] = 'Inconsistent data policy in channel with wmo:dataPolicy'  # noqa
+                                return status
+
+                    except IndexError:
+                        LOGGER.debug('Topic has no data policy')
 
                     LOGGER.debug('Validating topic in link channel')
                     if not self.th.validate(link['channel']):

--- a/tests/data/wcmp2-failing-invalid-link-channel-data-policy.json
+++ b/tests/data/wcmp2-failing-invalid-link-channel-data-policy.json
@@ -1,0 +1,167 @@
+{
+    "id": "urn:wmo:md:ca-eccc-msc:weather.observations.swob-realtime",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
+    ],
+    "time": {
+        "interval": [
+            "2010-11-11T11:11:11Z",
+            ".."
+        ],
+        "resolution": "PT1H"
+    },
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -142,
+                    28
+                ],
+                [
+                    -142,
+                    82
+                ],
+                [
+                    -52,
+                    82
+                ],
+                [
+                    -52,
+                    28
+                ],
+                [
+                    -142,
+                    28
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "title": "Surface weather observations",
+        "description": "Surface Observations measured at the automatic and manual stations of the Environment and Climate Change Canada and partners networks, either for a single station, or for the stations of specific provinces and territories (last 30 days)",
+        "themes": [
+            {
+                "concepts": [
+                    {
+                        "id": "Weather"
+                    },
+                    {
+                        "id": "Archives"
+                    },
+                    {
+                        "id": "Precipitation"
+                    },
+                    {
+                        "id": "Air temperature"
+                    },
+                    {
+                        "id": "Humidity"
+                    },
+                    {
+                        "id": "Snow"
+                    },
+                    {
+                        "id": "Wind"
+                    },
+                    {
+                        "id": "Meteorological data"
+                    }
+                ],
+                "scheme": "https://library-archives.canada.ca/eng/services/government-canada/controlled-vocabularies-government-canada/pages/controlled-vocabularies-government-canada.aspx"
+            },
+            {
+                "concepts": [
+                    {
+                        "id": "weather"
+                    }
+                ],
+                "scheme": "https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline"
+            }
+        ],
+        "contacts": [
+            {
+                "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+                "position": "National Inquiry Response Team",
+                "phones": [
+                    {
+                        "value": "+18199972800"
+                    }
+                ],
+                "emails": [
+                    {
+                        "value": "enviroinfo@ec.gc.ca"
+                    }
+                ],
+                "addresses": [
+                    {
+                        "deliveryPoint": [
+                            "77 Westmorland Street, suite 260"
+                        ],
+                        "city": "Fredericton",
+                        "administrativeArea": "NB",
+                        "postalCode": "E3B 6Z4",
+                        "country": "Canada"
+                    }
+                ],
+                "links": [
+                    {
+                        "rel": "canonical",
+                        "type": "text/html",
+                        "href": "https://eccc-msc.github.io/open-data"
+                    }
+                ],
+                "contactInstructions": "via email",
+                "roles": [
+                    "host",
+                    "producer"
+                ]
+            }
+        ],
+        "type": "dataset",
+        "created": "2018-01-01T11:11:11Z",
+        "updated": "2022-06-22T12:42:46Z",
+        "wmo:dataPolicy": "recommended"
+    },
+    "links": [
+        {
+            "rel": "stations",
+            "href": "https://dd.weather.gc.ca/observations/doc/swob-xml_station_list.csv",
+            "type": "text/csv",
+            "title": "Stations associated with this dataset"
+        },
+        {
+            "rel": "data",
+            "href": "https://dd.weather.gc.ca/observations/swob-ml",
+            "type": "text/html",
+            "hreflang": "en",
+            "title": "Raw data download (CSV files)"
+        },
+        {
+            "rel": "items",
+            "href": "https://api.weather.gc.ca/collections/swob-realtime/items",
+            "type": "application/json",
+            "title": "Data access API interface"
+        },
+        {
+            "rel": "related",
+            "href": "https://eccc-msc.github.io/open-data/msc-data/obs_station/readme_obs_insitu_swobdatamart_en",
+            "type": "text/html",
+            "title": "Documentation"
+        },
+        {
+            "href": "https://eccc-msc.github.io/open-data/licence/readme_en",
+            "type": "text/html",
+            "rel": "license",
+            "title": "Environment and Climate Change Canada Data Servers End-use Licence"
+        },
+        {
+            "rel": "items",
+            "href": "mqtt://example.org:8883",
+            "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/experimental/surface-based-observations/synop",
+            "type": "application/json",
+            "title": "Data notifications"
+        }
+    ]
+}

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -265,6 +265,23 @@ class WCMP2ETSTest(unittest.TestCase):
             self.assertEqual(codes.count('PASSED'), 11)
             self.assertEqual(codes.count('SKIPPED'), 0)
 
+    def test_fail_invalid_link_channel_data_policy(self):
+        """
+        Simple tests for a failing record with a link channel data policy that
+        does not match wmo:dataPolicy
+        """
+
+        with open(get_test_file_path('data/wcmp2-failing-invalid-link-channel-data-policy.json')) as fh:  # noqa
+            record = json.load(fh)
+            ts = WMOCoreMetadataProfileTestSuite2(record)
+            results = ts.run_tests()
+
+            codes = [r['code'] for r in results['tests']]
+
+            self.assertEqual(codes.count('FAILED'), 1)
+            self.assertEqual(codes.count('PASSED'), 11)
+            self.assertEqual(codes.count('SKIPPED'), 0)
+
 
 class WCMP2KPITest(unittest.TestCase):
     """WCMP KPI tests of tests"""


### PR DESCRIPTION
This PR adds a comparison check between the data policy in a link channel and `properties.wmo:dataPolicy`.